### PR TITLE
Problem: no introspection into PersistentMap

### DIFF
--- a/cicomponents-api/src/main/java/org/cicomponents/PersistentMap.java
+++ b/cicomponents-api/src/main/java/org/cicomponents/PersistentMap.java
@@ -8,8 +8,7 @@
 package org.cicomponents;
 
 import java.io.Serializable;
+import java.util.Map;
 
-public interface PersistentMap {
-    <T extends Serializable> void put(String key, T value);
-    <T extends Serializable> T get(String key);
+public interface PersistentMap extends Map<String, Serializable> {
 }

--- a/cicomponents-core/src/main/java/org/cicomponents/core/PersistentMapImpl.java
+++ b/cicomponents-core/src/main/java/org/cicomponents/core/PersistentMapImpl.java
@@ -15,8 +15,10 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 @Slf4j
 @Component(scope = ServiceScope.SINGLETON)
@@ -25,11 +27,51 @@ public class PersistentMapImpl implements PersistentMap {
     @Reference
     protected volatile PersistentMapImplementation map;
 
-    @Override public <T extends Serializable> void put(String key, T value) {
-        map.put(key, value);
+    @Override public int size() {
+        return map.size();
     }
 
-    @Override public <T extends Serializable> T get(String key) {
+    @Override public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override public Serializable get(Object key) {
         return map.get(key);
+    }
+
+    @Override public Serializable put(String key, Serializable value) {
+        return map.put(key, value);
+    }
+
+    @Override public Serializable remove(Object key) {
+        return map.remove(key);
+    }
+
+    @Override public void putAll(Map<? extends String, ? extends Serializable> m) {
+        map.putAll(m);
+    }
+
+    @Override public void clear() {
+        map.clear();
+    }
+
+    @Override public Set<String> keySet() {
+        return map.keySet();
+    }
+
+    @Override public Collection<Serializable> values() {
+        return map.values();
+    }
+
+    @Override public Set<Entry<String, Serializable>> entrySet() {
+        return map.entrySet();
     }
 }

--- a/cicomponents-core/src/main/java/org/cicomponents/core/SimpleFilePersistentMap.java
+++ b/cicomponents-core/src/main/java/org/cicomponents/core/SimpleFilePersistentMap.java
@@ -11,12 +11,17 @@ import lombok.SneakyThrows;
 
 import lombok.extern.slf4j.Slf4j;
 import org.cicomponents.PersistentMapImplementation;
-import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ServiceScope;
 
 import java.io.*;
-import java.nio.file.Paths;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component(property = "type=simplefile", scope = ServiceScope.SINGLETON)
@@ -32,24 +37,101 @@ public class SimpleFilePersistentMap implements PersistentMapImplementation {
         assert mkdirs;
     }
 
-    @SneakyThrows
-    @Override public <T extends Serializable> void put(String key, T value) {
-        File file = new File(this.file + "/" + key);
-        FileOutputStream stream = new FileOutputStream(file);
-        new ObjectOutputStream(stream).writeObject(value);
-        stream.close();
+    @Override public int size() {
+        return file.listFiles().length;
+    }
 
+    @Override public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override public boolean containsKey(Object key) {
+        File file = new File(this.file + "/" + key);
+        return file.exists();
+    }
+
+    @Override public boolean containsValue(Object value) {
+        return values().contains(value);
     }
 
     @SneakyThrows
-    @Override public <T extends Serializable> T get(String key) {
+    @Override public Serializable get(Object key) {
         File file = new File(this.file + "/" + key);
         if (!file.exists()) {
             return null;
         }
         FileInputStream stream = new FileInputStream(file);
-        @SuppressWarnings("unchecked")
-        T t = (T) new ObjectInputStream(stream).readObject();
-        return t;
+        return (Serializable) new ObjectInputStream(stream).readObject();
     }
+
+    @SneakyThrows
+    @Override public Serializable put(String key, Serializable value) {
+                File file = new File(this.file + "/" + key);
+        FileOutputStream stream = new FileOutputStream(file);
+        new ObjectOutputStream(stream).writeObject(value);
+        stream.close();
+        return value;
+    }
+
+    @Override public Serializable remove(Object key) {
+        Serializable result = get(key);
+        File file = new File(this.file + "/" + key);
+        file.delete();
+        return result;
+    }
+
+    @Override public void putAll(Map<? extends String, ? extends Serializable> m) {
+        m.forEach(this::put);
+    }
+
+    @SneakyThrows
+    @Override public void clear() {
+        Files.walkFileTree(file.toPath(), new SimpleFileVisitor<Path>() {
+            @Override public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                    throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        file.mkdirs();
+    }
+
+    @Override public Set<String> keySet() {
+        return Arrays.stream(file.listFiles()).map(File::getName).collect(Collectors.toSet());
+    }
+
+    @Override public Collection<Serializable> values() {
+        return entrySet().stream().map(Map.Entry::getValue).collect(Collectors.toList());
+    }
+
+    @Override public Set<Entry<String, Serializable>> entrySet() {
+        return Arrays.stream(file.listFiles())
+                     .map(file -> new Entry<String, Serializable>() {
+                         @Override public String getKey() {
+                             return file.getName();
+                         }
+
+                         @Override public Serializable getValue() {
+                             return get(getKey());
+                         }
+
+                         @Override public Serializable setValue(Serializable value) {
+                             return put(getKey(), value);
+                         }
+
+                         @Override public boolean equals(Object o) {
+                             return get(getKey()).equals(o);
+                         }
+
+                         @Override public int hashCode() {
+                             return getKey().hashCode();
+                         }
+                     }).collect(Collectors.toSet());
+    }
+
 }

--- a/cicomponents-core/src/main/java/org/cicomponents/core/command/MapListCommand.java
+++ b/cicomponents-core/src/main/java/org/cicomponents/core/command/MapListCommand.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cicomponents.core.command;
+
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.table.ShellTable;
+import org.cicomponents.PersistentMap;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+import java.io.Serializable;
+import java.util.Map;
+
+@Command(scope = "map", name = "list", description = "List keys and values in PersistentMap")
+@Service
+public class MapListCommand implements Action {
+    @Override public Object execute() throws Exception {
+        BundleContext context = FrameworkUtil.getBundle(MapListCommand.class).getBundleContext();
+        ServiceReference<PersistentMap> reference = context
+                .getServiceReference(PersistentMap.class);
+        PersistentMap map = context.getService(reference);
+
+        // Build the table
+        ShellTable table = new ShellTable();
+
+        table.column("Key").alignLeft();
+        table.column("Value").alignLeft();
+        table.emptyTableText("No keys defined");
+
+        for (Map.Entry<String, Serializable> entry : map.entrySet()) {
+            table.addRow().addContent(entry.getKey(), entry.getValue());
+        }
+
+        // Print it
+        table.print(System.out);
+
+        context.ungetService(reference);
+
+        return null;
+    }
+}

--- a/cicomponents-git/src/main/java/org/cicomponents/git/impl/LatestRevisionGitBranchMonitor.java
+++ b/cicomponents-git/src/main/java/org/cicomponents/git/impl/LatestRevisionGitBranchMonitor.java
@@ -39,7 +39,7 @@ public class LatestRevisionGitBranchMonitor extends AbstractLocalGitMonitor {
     private void checkLatest() throws IOException {
         synchronized (git) {
             String headRefName = git.getRepository().findRef("refs/heads/" + branch).getObjectId().getName();
-            String knownHead = getEnvironment().getPersistentMap().get(headRefName);
+            String knownHead = (String) getEnvironment().getPersistentMap().get(headRefName);
             if (knownHead != null) {
                 head = ObjectId.fromString(knownHead);
             }

--- a/cicomponents-github/src/main/java/org/cicomponents/github/impl/GithubOAuthTokenProvisioner.java
+++ b/cicomponents-github/src/main/java/org/cicomponents/github/impl/GithubOAuthTokenProvisioner.java
@@ -121,7 +121,7 @@ public class GithubOAuthTokenProvisioner implements GithubOAuthFinalizer {
     @SneakyThrows
     @Synchronized("registrations")
     protected void addApplicationCredentialsProvider(GithubApplicationCredentialsProvider provider) {
-        ArrayList<OAuth2AccessToken> tokens = persistentMap.get(provider.getClientId());
+        ArrayList<OAuth2AccessToken> tokens = (ArrayList<OAuth2AccessToken>) persistentMap.get(provider.getClientId());
         if (tokens == null) {
             if (pendingProvisioning.contains(provider.getClientId())) {
                 return;


### PR DESCRIPTION
There is no way to list keys, for example.

Solution: make PersistentMap implement Map<String, Serializable> to
provide all standard tools to work with a Map.

Also, add `map:list` console command.
