### PR TITLE
Problem: CI's Build#deactivate removes listeners on deactivation

### DIFF
--- a/cicomponents-ci/src/main/java/org/cicomponents/ci/Build.java
+++ b/cicomponents-ci/src/main/java/org/cicomponents/ci/Build.java
@@ -88,16 +88,6 @@ public class Build {
         pullRequests.addResourceListener(prListener);
     }
 
-    @Deactivate
-    protected void deactivate() {
-        if (masterListener != null) {
-            master.removeResourceListener(masterListener);
-        }
-        if (prListener != null) {
-            pullRequests.removeResourceListener(prListener);
-        }
-    }
-
     private class Builder implements Supplier<Boolean> {
         private final GitRevision resource;
 


### PR DESCRIPTION
This might result in some of the listener being absent (if another
emitter is rebound)

Solution: drop the listeners removal for now
