### PR TITLE
Problem: Resource#acquire() and #close() names are not matching

### DIFF
--- a/cicomponents-api/src/main/java/org/cicomponents/Resource.java
+++ b/cicomponents-api/src/main/java/org/cicomponents/Resource.java
@@ -9,5 +9,8 @@ package org.cicomponents;
 
 public interface Resource extends AutoCloseable {
     default void acquire() {}
-    default void close() {}
+    default void release() {}
+    default void close() {
+        release();
+    }
 }

--- a/cicomponents-fs/src/main/java/org/cicomponents/fs/impl/WorkingDirectoryProviderImpl.java
+++ b/cicomponents-fs/src/main/java/org/cicomponents/fs/impl/WorkingDirectoryProviderImpl.java
@@ -33,7 +33,7 @@ public class WorkingDirectoryProviderImpl implements WorkingDirectoryProvider {
             }
 
             @SneakyThrows
-            @Override public void close() {
+            @Override public void release() {
                 log.info("Removing working directory {}", path);
                 Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
                     @Override public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)

--- a/cicomponents-git/src/main/java/org/cicomponents/git/impl/AbstractLocalGitMonitor.java
+++ b/cicomponents-git/src/main/java/org/cicomponents/git/impl/AbstractLocalGitMonitor.java
@@ -92,7 +92,7 @@ public abstract class AbstractLocalGitMonitor extends AbstractGitMonitor {
         }
 
         @Synchronized("counter")
-        @Override public void close() {
+        @Override public void release() {
             if (counter.decrementAndGet() == 0) {
                 log.info("Cleaning up {}", clone);
                 clone.close();

--- a/cicomponents-github/src/main/java/org/cicomponents/github/impl/PullRequestMonitor.java
+++ b/cicomponents-github/src/main/java/org/cicomponents/github/impl/PullRequestMonitor.java
@@ -177,7 +177,7 @@ public class PullRequestMonitor extends AbstractResourceEmitter<GithubPullReques
         }
 
         @Synchronized("counter")
-        @Override public void close() {
+        @Override public void release() {
             if (counter.decrementAndGet() == 0) {
                 log.info("Cleaning up {}", git);
                 git.close();


### PR DESCRIPTION
The `close()` method name comes from implementing `AutoCloseable()`
but it doesn't fit the naming scheme with `acquire()`

Solution: introduce `release()` method and make `close()` call
`release()` by default.
