### PR TITLE
Problem: PersistentMap use of Serializable doesn't work

### DIFF
--- a/cicomponents-api/src/main/java/org/cicomponents/PersistentMap.java
+++ b/cicomponents-api/src/main/java/org/cicomponents/PersistentMap.java
@@ -7,8 +7,10 @@
  */
 package org.cicomponents;
 
-import java.io.Serializable;
+import org.osgi.framework.Bundle;
+
 import java.util.Map;
 
-public interface PersistentMap extends Map<String, Serializable> {
+public interface PersistentMap {
+    <T> Map<String, T> getMapForBundle(Bundle bundle);
 }

--- a/cicomponents-api/src/main/resources/org/cicomponents/PersistentMap.md
+++ b/cicomponents-api/src/main/resources/org/cicomponents/PersistentMap.md
@@ -7,23 +7,17 @@ This simple interface allows to store any serializable (i.e. having a class impl
 protected volatile PersistentMap persistentMap;
 ```
 
-`PersistentMap` implements `Map<String, Serializable>`
+`PersistentMap#getMapForBundle(bundle)` returns a `Map<String, Serializable>` for the bundle.
 
 ## Console commands
 
 ### map:list
 
-This command lists key/value pairs recorded:
+This command lists key/value pairs recorded for a bundle:
 
 ```
-ci@cicomponents> map:list
-Key                                                                                   | Value
-----------------------------------------------------------------------------------------------------------------------------------
-github-pr-status-cicomponents-cicomponents-7-7e9e5890e0ac71913ee0961dd730fe3d5b35b176 | Wed Jul 20 14:24:34 ICT 2016
-github-pr-status-cicomponents-cicomponents-6-fe5eac22c73828abc240a4481536252208ee3c83 | Wed Jul 20 14:19:27 ICT 2016
-e9ea6783cbc071cdfbf3                                                                  | [1f2029ee38990575c7e68e8393480349a3856aca]
-github-pr-status-cicomponents-cicomponents-6-8c55fa8990a844cf17484f317970d8dc73aae4a1 | Wed Jul 20 14:21:07 ICT 2016
-793ab61b82808bca8e8cebc147730f4d2c1dac64                                              | 793ab61b82808bca8e8cebc147730f4d2c1dac64
-0dd68708d7bf7ff1887af004876d0212b797edb2                                              | 0dd68708d7bf7ff1887af004876d0212b797edb2
-561fe804eba8469e4c36e5e9fd6503ba0eb9d60d                                              | 561fe804eba8469e4c36e5e9fd6503ba0eb9d60d
+ci@cicomponents> map:list 97
+Key                                      | Value
+-----------------------------------------------------------------------------------
+9e914d735c1bc4405cac9ceb7c4fb1c345ff4629 | 9e914d735c1bc4405cac9ceb7c4fb1c345ff4629
 ```

--- a/cicomponents-core/build.gradle
+++ b/cicomponents-core/build.gradle
@@ -5,6 +5,8 @@ dependencies {
     compile 'org.apache.karaf.shell:org.apache.karaf.shell.console:4.0.5'
     compile 'org.apache.karaf.shell:org.apache.karaf.shell.table:4.0.5'
     compile 'org.apache.karaf.config:org.apache.karaf.config.core:4.0.5'
+
+    compile 'com.esotericsoftware:kryo:4.0.0'
 }
 
 

--- a/cicomponents-core/src/main/java/org/cicomponents/core/PersistentMapImpl.java
+++ b/cicomponents-core/src/main/java/org/cicomponents/core/PersistentMapImpl.java
@@ -10,6 +10,7 @@ package org.cicomponents.core;
 import lombok.extern.slf4j.Slf4j;
 import org.cicomponents.PersistentMap;
 import org.cicomponents.PersistentMapImplementation;
+import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
@@ -27,51 +28,8 @@ public class PersistentMapImpl implements PersistentMap {
     @Reference
     protected volatile PersistentMapImplementation map;
 
-    @Override public int size() {
-        return map.size();
+    @Override public <T> Map<String, T> getMapForBundle(Bundle bundle) {
+        return map.getMapForBundle(bundle);
     }
 
-    @Override public boolean isEmpty() {
-        return map.isEmpty();
-    }
-
-    @Override public boolean containsKey(Object key) {
-        return map.containsKey(key);
-    }
-
-    @Override public boolean containsValue(Object value) {
-        return map.containsValue(value);
-    }
-
-    @Override public Serializable get(Object key) {
-        return map.get(key);
-    }
-
-    @Override public Serializable put(String key, Serializable value) {
-        return map.put(key, value);
-    }
-
-    @Override public Serializable remove(Object key) {
-        return map.remove(key);
-    }
-
-    @Override public void putAll(Map<? extends String, ? extends Serializable> m) {
-        map.putAll(m);
-    }
-
-    @Override public void clear() {
-        map.clear();
-    }
-
-    @Override public Set<String> keySet() {
-        return map.keySet();
-    }
-
-    @Override public Collection<Serializable> values() {
-        return map.values();
-    }
-
-    @Override public Set<Entry<String, Serializable>> entrySet() {
-        return map.entrySet();
-    }
 }

--- a/cicomponents-github/src/main/java/org/cicomponents/github/impl/GithubOAuthTokenProvisioner.java
+++ b/cicomponents-github/src/main/java/org/cicomponents/github/impl/GithubOAuthTokenProvisioner.java
@@ -37,13 +37,15 @@ import java.util.stream.IntStream;
 public class GithubOAuthTokenProvisioner implements GithubOAuthFinalizer {
 
     @Reference
-    protected PersistentMap persistentMap;
+    protected PersistentMap pMap;
+    private Map<String, Object> persistentMap;
 
     private ComponentContext context;
 
     @Activate
     protected void activate(ComponentContext context) {
         this.context = context;
+        this.persistentMap = pMap.getMapForBundle(context.getBundleContext().getBundle());
     }
 
     private Map<UUID, Collection<OAuthTokenProvider>> registrations = new HashMap<>();

--- a/cicomponents-github/src/main/java/org/cicomponents/github/impl/PullRequestMonitor.java
+++ b/cicomponents-github/src/main/java/org/cicomponents/github/impl/PullRequestMonitor.java
@@ -44,12 +44,14 @@ public class PullRequestMonitor extends AbstractResourceEmitter<GithubPullReques
     @Getter
     private final String repository;
     private final Environment environment;
+    private final Map<String, Object> persistentMap;
 
     private volatile GithubOAuthTokenProvider tokenProvider;
     private final ServiceTracker<GithubOAuthTokenProvider, Boolean> serviceTracker;
 
     public PullRequestMonitor(Environment environment, Dictionary<String, ?> dictionary) {
         this.environment = environment;
+        persistentMap = environment.getPersistentMap().getMapForBundle(FrameworkUtil.getBundle(PullRequestMonitor.class));
         context = FrameworkUtil.getBundle(PullRequestMonitor.class).getBundleContext();
         repository = (String) dictionary.get("github-repository");
 
@@ -93,8 +95,7 @@ public class PullRequestMonitor extends AbstractResourceEmitter<GithubPullReques
     }
 
     private void checkPullRequest(GHPullRequest pr) {
-        Object o = environment.getPersistentMap()
-                          .get(getIssueStatusKey(pr));
+        Object o = persistentMap.get(getIssueStatusKey(pr));
         if (o == null) { // no status available for it
             log.info("No status available for {}#{}-{}", repository,
                      pr.getNumber(), pr.getHead().getSha());
@@ -130,8 +131,7 @@ public class PullRequestMonitor extends AbstractResourceEmitter<GithubPullReques
         log.info("Emitting fork {}#{}", name, pr.getHead().getSha());
 
         GithubPullRequest pullRequest = new GithubPullRequestResource(git, pr, directory);
-        environment.getPersistentMap()
-                   .put(getIssueStatusKey(pr), new Date());
+        persistentMap.put(getIssueStatusKey(pr), new Date());
         emit(new SimpleResourceHolder<>(pullRequest));
     }
 


### PR DESCRIPTION
It can't find classes included in other bundles, because
ObjectInputStream uses Class.forName which is a big no-no in OSGi.

Solution: Change PersistentMap interface to provide maps for bundles.
This also makes bundle maps isolated from each other, reducing
conflicts greatly.

Closes #11
