### PR TITLE
Problem: PersistentMap#getMapForBundle() is cumbersome

### DIFF
--- a/cicomponents-api/src/main/java/org/cicomponents/PersistentMap.java
+++ b/cicomponents-api/src/main/java/org/cicomponents/PersistentMap.java
@@ -11,6 +11,5 @@ import org.osgi.framework.Bundle;
 
 import java.util.Map;
 
-public interface PersistentMap {
-    <T> Map<String, T> getMapForBundle(Bundle bundle);
+public interface PersistentMap extends Map<String, Object> {
 }

--- a/cicomponents-api/src/main/java/org/cicomponents/PersistentMapImplementation.java
+++ b/cicomponents-api/src/main/java/org/cicomponents/PersistentMapImplementation.java
@@ -7,11 +7,16 @@
  */
 package org.cicomponents;
 
+import org.osgi.framework.Bundle;
+
+import java.util.Map;
+
 /**
  * PersistentMapImplementation, unlike {@link PersistentMap} is the
  * interface to be implemented by actual implementation of a persistence
- * map so that they can be easily swapped in the singleton {@link PersistentMap} service
+ * map so that they can be easily swapped in the {@link PersistentMap} service
  * implementation.
  */
-public interface PersistentMapImplementation extends PersistentMap {
+public interface PersistentMapImplementation  {
+    <T> Map<String, T> getMapForBundle(Bundle bundle);
 }

--- a/cicomponents-api/src/main/resources/org/cicomponents/PersistentMap.md
+++ b/cicomponents-api/src/main/resources/org/cicomponents/PersistentMap.md
@@ -7,7 +7,7 @@ This simple interface allows to store any serializable (i.e. having a class impl
 protected volatile PersistentMap persistentMap;
 ```
 
-`PersistentMap#getMapForBundle(bundle)` returns a `Map<String, Serializable>` for the bundle.
+`PersistentMap#getMapForBundle(bundle)` implements `Map<String, Serializable>` and is scoped to a using bundle. This prevents the leakage of the map outside of the bundle's scope.
 
 ## Console commands
 

--- a/cicomponents-core/src/main/java/org/cicomponents/core/PersistentMapImpl.java
+++ b/cicomponents-core/src/main/java/org/cicomponents/core/PersistentMapImpl.java
@@ -7,10 +7,13 @@
  */
 package org.cicomponents.core;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.cicomponents.PersistentMap;
 import org.cicomponents.PersistentMapImplementation;
 import org.osgi.framework.Bundle;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
@@ -22,14 +25,66 @@ import java.util.Map;
 import java.util.Set;
 
 @Slf4j
-@Component(scope = ServiceScope.SINGLETON)
+@Component(scope = ServiceScope.BUNDLE)
 public class PersistentMapImpl implements PersistentMap {
 
+    @Getter
     @Reference
-    protected volatile PersistentMapImplementation map;
+    protected volatile PersistentMapImplementation implementation;
 
-    @Override public <T> Map<String, T> getMapForBundle(Bundle bundle) {
-        return map.getMapForBundle(bundle);
+    private Map<String, Object> map;
+
+    @Activate
+    protected void activate(ComponentContext context) {
+        map = implementation.getMapForBundle(context.getUsingBundle());
     }
 
+
+    @Override public int size() {
+        return map.size();
+    }
+
+    @Override public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override public Object get(Object key) {
+        return map.get(key);
+    }
+
+    @Override public Object put(String key, Object value) {
+        return map.put(key, value);
+    }
+
+    @Override public Object remove(Object key) {
+        return map.remove(key);
+    }
+
+    @Override public void putAll(Map<? extends String, ?> m) {
+        map.putAll(m);
+    }
+
+    @Override public void clear() {
+        map.clear();
+    }
+
+    @Override public Set<String> keySet() {
+        return map.keySet();
+    }
+
+    @Override public Collection<Object> values() {
+        return map.values();
+    }
+
+    @Override public Set<Entry<String, Object>> entrySet() {
+        return map.entrySet();
+    }
 }

--- a/cicomponents-core/src/main/java/org/cicomponents/core/command/MapListCommand.java
+++ b/cicomponents-core/src/main/java/org/cicomponents/core/command/MapListCommand.java
@@ -13,6 +13,7 @@ import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.apache.karaf.shell.table.ShellTable;
 import org.cicomponents.PersistentMap;
+import org.cicomponents.core.PersistentMapImpl;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
@@ -32,7 +33,8 @@ public class MapListCommand implements Action {
         ServiceReference<PersistentMap> reference = context
                 .getServiceReference(PersistentMap.class);
         Bundle targetBundle = bundle.getBundleContext().getBundle(Long.valueOf(bundleId));
-        Map<String, Object> map = context.getService(reference).getMapForBundle(targetBundle);
+        Map<String, Object> map = ((PersistentMapImpl)context.getService(reference))
+                .getImplementation().getMapForBundle(targetBundle);
 
         // Build the table
         ShellTable table = new ShellTable();

--- a/cicomponents-git/src/main/java/org/cicomponents/git/impl/LatestRevisionGitBranchMonitor.java
+++ b/cicomponents-git/src/main/java/org/cicomponents/git/impl/LatestRevisionGitBranchMonitor.java
@@ -36,8 +36,7 @@ public class LatestRevisionGitBranchMonitor extends AbstractLocalGitMonitor {
     public LatestRevisionGitBranchMonitor(Environment environment, Dictionary<String, ?> dictionary) {
         super(environment, dictionary);
         branch = (String) dictionary.get("branch");
-        persistentMap = environment.getPersistentMap().getMapForBundle(
-                FrameworkUtil.getBundle(LatestRevisionGitBranchMonitor.class));
+        persistentMap = environment.getPersistentMap();
         checkLatest();
     }
 

--- a/cicomponents-github/src/main/java/org/cicomponents/github/impl/GithubOAuthTokenProvisioner.java
+++ b/cicomponents-github/src/main/java/org/cicomponents/github/impl/GithubOAuthTokenProvisioner.java
@@ -37,15 +37,13 @@ import java.util.stream.IntStream;
 public class GithubOAuthTokenProvisioner implements GithubOAuthFinalizer {
 
     @Reference
-    protected PersistentMap pMap;
-    private Map<String, Object> persistentMap;
+    protected PersistentMap persistentMap;
 
     private ComponentContext context;
 
     @Activate
     protected void activate(ComponentContext context) {
         this.context = context;
-        this.persistentMap = pMap.getMapForBundle(context.getBundleContext().getBundle());
     }
 
     private Map<UUID, Collection<OAuthTokenProvider>> registrations = new HashMap<>();

--- a/cicomponents-github/src/main/java/org/cicomponents/github/impl/PullRequestMonitor.java
+++ b/cicomponents-github/src/main/java/org/cicomponents/github/impl/PullRequestMonitor.java
@@ -51,7 +51,7 @@ public class PullRequestMonitor extends AbstractResourceEmitter<GithubPullReques
 
     public PullRequestMonitor(Environment environment, Dictionary<String, ?> dictionary) {
         this.environment = environment;
-        persistentMap = environment.getPersistentMap().getMapForBundle(FrameworkUtil.getBundle(PullRequestMonitor.class));
+        persistentMap = environment.getPersistentMap();
         context = FrameworkUtil.getBundle(PullRequestMonitor.class).getBundleContext();
         repository = (String) dictionary.get("github-repository");
 


### PR DESCRIPTION
It's an unusual API and requires the retrieval of the current bundle. It also
allows peaking into other bundles' peristent maps, which is not great.

Solution: make PersistentMapImpl scoped to a using bundle and make it
provision map implementation itself.
