### PR TITLE
Problem: no easy, conventional way to indicate the status of the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,8 @@ configurations {
 dependencies {
     dist project(':cicomponents-api')
     dist project(':cicomponents-common')
+    dist project(':cicomponents-badges-api')
+    dist project(':cicomponents-badges')
     dist project(':cicomponents-core')
     dist project(':cicomponents-fs-api')
     dist project(':cicomponents-fs')

--- a/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeColor.java
+++ b/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeColor.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cicomponents.badges;
+
+import lombok.Value;
+
+@Value
+public class BadgeColor implements BadgeProperty {
+    private String text;
+}

--- a/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeMaker.java
+++ b/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeMaker.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cicomponents.badges;
+
+public interface BadgeMaker {
+    static BadgeSubject subject(String text) {
+        return new BadgeSubject(text);
+    }
+    static BadgeStatus status(String text) {
+        return new BadgeStatus(text);
+    }
+    static BadgeColor color(String text) {
+        return new BadgeColor(text);
+    }
+    static BadgeStatusColor statusColor(String text) {
+        return new BadgeStatusColor(text);
+    }
+
+    byte[] make(BadgeProperty ...properties);
+}

--- a/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeProperty.java
+++ b/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeProperty.java
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cicomponents.badges;
+
+public interface BadgeProperty {}

--- a/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeStatus.java
+++ b/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeStatus.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cicomponents.badges;
+
+import lombok.Value;
+
+@Value
+public class BadgeStatus implements BadgeProperty {
+    private String text;
+}

--- a/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeStatusColor.java
+++ b/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeStatusColor.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cicomponents.badges;
+
+import lombok.Value;
+
+@Value
+public class BadgeStatusColor implements BadgeProperty {
+    private String text;
+}

--- a/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeSubject.java
+++ b/cicomponents-badges-api/src/main/java/org/cicomponents/badges/BadgeSubject.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cicomponents.badges;
+
+import lombok.Value;
+
+@Value
+public class BadgeSubject implements BadgeProperty {
+    private String text;
+}

--- a/cicomponents-badges/build.gradle
+++ b/cicomponents-badges/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    compile project(':cicomponents-badges-api')
+    compile 'org.jfree:jfreesvg:3.1'
+}

--- a/cicomponents-badges/src/main/java/org/cicomponents/badges/impl/ShieldStyleFlatBadgeMaker.java
+++ b/cicomponents-badges/src/main/java/org/cicomponents/badges/impl/ShieldStyleFlatBadgeMaker.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cicomponents.badges.impl;
+
+import com.google.common.io.CharStreams;
+import lombok.SneakyThrows;
+import org.cicomponents.badges.*;
+import org.jfree.graphics2d.svg.SVGGraphics2D;
+import org.osgi.service.component.annotations.Component;
+
+import java.awt.*;
+import java.io.InputStreamReader;
+import java.util.*;
+
+@Component(property = {"type=shield", "format=svg", "style=flat"})
+public class ShieldStyleFlatBadgeMaker implements BadgeMaker {
+
+    @SneakyThrows
+    @Override public byte[] make(BadgeProperty... properties) {
+        java.util.List<BadgeProperty> props = Arrays.asList(properties);
+        BadgeSubject subject = (BadgeSubject) props.stream().filter(prop -> prop instanceof BadgeSubject).findFirst()
+                                                  .orElse(BadgeMaker.subject("Unknown"));
+        BadgeStatus status = (BadgeStatus) props.stream().filter(prop -> prop instanceof BadgeStatus).findFirst()
+                                                   .orElse(BadgeMaker.status("unknown"));
+        BadgeColor color = (BadgeColor) props.stream().filter(prop -> prop instanceof BadgeColor).findFirst()
+                                               .orElse(BadgeMaker.color("#555"));
+
+        BadgeStatusColor statusColor =
+                (BadgeStatusColor) props.stream().filter(prop -> prop instanceof BadgeStatusColor)
+                                        .findFirst()
+                                        .orElse(BadgeMaker.statusColor("#4c1"));
+
+        int subjectWidth = measureText(subject.getText());
+        int statusWidth = measureText(status.getText());
+
+        if (subjectWidth % 2 == 0) { subjectWidth++; }
+        if (statusWidth % 2 == 0) { statusWidth++; }
+
+        subjectWidth += 10;
+        statusWidth += 10;
+
+        int width = subjectWidth + statusWidth;
+
+        String template = CharStreams
+                .toString(new InputStreamReader(getClass().getResourceAsStream("shield-flat.svg.template")));
+
+        String svg = template
+                .replaceAll("\\{\\{width\\}\\}", String.valueOf(width))
+                .replaceAll("\\{\\{subjectWidth\\}\\}", String.valueOf(subjectWidth))
+                .replaceAll("\\{\\{statusWidth\\}\\}", String.valueOf(statusWidth))
+                .replaceAll("\\{\\{halfWidth\\}\\}", String.valueOf(subjectWidth/2))
+                .replaceAll("\\{\\{quarterWidth\\}\\}", String.valueOf(subjectWidth + (statusWidth/2 - 1)))
+                .replaceAll("\\{\\{subject\\}\\}", subject.getText())
+                .replaceAll("\\{\\{status\\}\\}", status.getText())
+                .replaceAll("\\{\\{color\\}\\}", colorscheme.getOrDefault(color.getText(), color.getText()))
+                .replaceAll("\\{\\{alternateColor\\}\\}", colorscheme.getOrDefault(statusColor.getText(), statusColor
+                        .getText()));
+
+
+        return svg.getBytes();
+    }
+
+   
+    private Font getFont() {
+        return Font.decode("Verdana 11");
+    }
+
+    private int measureText(String text) {
+        SVGGraphics2D g = new SVGGraphics2D(0, 0);
+        FontMetrics metrics = g.getFontMetrics(getFont());
+        return metrics.stringWidth(text);
+    }
+
+    private static Map<String, String> colorscheme = new HashMap<>();
+
+    static {
+        colorscheme.put("brightgreen", "#4c1");
+        colorscheme.put("green", "#97CA00");
+        colorscheme.put("yellow", "#dfb317");
+        colorscheme.put("yellowgreen", "#a4a61d");
+        colorscheme.put("orange", "#fe7d37");
+        colorscheme.put("red", "#e05d44");
+        colorscheme.put("blue", "#007ec6");
+        colorscheme.put("grey", "#555");
+        colorscheme.put("gray", "#555");
+        colorscheme.put("lightgrey", "#9f9f9f");
+        colorscheme.put("lightgray", "#9f9f9f");
+    }
+}

--- a/cicomponents-badges/src/main/resources/org/cicomponents/badges/impl/shield-flat.svg.template
+++ b/cicomponents-badges/src/main/resources/org/cicomponents/badges/impl/shield-flat.svg.template
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{width}}" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="{{width}}" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="{{subjectWidth}}" height="20" fill="{{color}}"/>
+    <rect x="{{subjectWidth}}" width="{{statusWidth}}" height="20" fill="{{alternateColor}}"/>
+    <rect width="{{width}}" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="{{quarterWidth}}" y="15" fill="#010101" fill-opacity=".3">{{status}}</text>
+    <text x="{{quarterWidth}}" y="14">{{status}}</text>
+    <text x="{{halfWidth}}" y="15" fill="#010101" fill-opacity=".3">{{subject}}</text>
+    <text x="{{halfWidth}}" y="14">{{subject}}</text>
+  </g>
+</svg>

--- a/cicomponents-ci/build.gradle
+++ b/cicomponents-ci/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compile project(':cicomponents-api')
     compile project(':cicomponents-git-api')
     compile project(':cicomponents-github-api')
+    compile project(':cicomponents-badges-api')
 
     compile 'org.gradle:gradle-tooling-api:2.13'
     dist    'org.gradle:gradle-tooling-api:2.13'

--- a/cicomponents-ci/src/main/java/org/cicomponents/ci/MasterListener.java
+++ b/cicomponents-ci/src/main/java/org/cicomponents/ci/MasterListener.java
@@ -8,10 +8,7 @@
 package org.cicomponents.ci;
 
 import lombok.SneakyThrows;
-import org.cicomponents.OutputProviderService;
-import org.cicomponents.ResourceEmitter;
-import org.cicomponents.ResourceHolder;
-import org.cicomponents.ResourceListener;
+import org.cicomponents.*;
 import org.cicomponents.git.GitRevision;
 import org.cicomponents.git.GitRevisionEmitter;
 import org.osgi.service.component.annotations.Component;
@@ -27,6 +24,9 @@ public class MasterListener implements ResourceListener<GitRevision> {
     @Reference
     protected OutputProviderService outputProviderService;
 
+    @Reference
+    protected PersistentMap pmap;
+
     /**
      * This method is invoked when a new {@link GitRevision} has been emitted.
      *
@@ -37,7 +37,12 @@ public class MasterListener implements ResourceListener<GitRevision> {
     @SneakyThrows
     public void onEmittedResource(ResourceHolder<GitRevision> holder, ResourceEmitter<GitRevision> emitter) {
         try (GitRevision resource = holder.acquire()) {
-          new Builder(resource, outputProviderService).get();
+            Boolean result = new Builder(resource, outputProviderService).get();
+            if (result) {
+                pmap.put("build-status", "passing");
+            } else {
+                pmap.put("build-status", "failed");
+            }
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,9 @@ include 'cicomponents-api'
 include 'cicomponents-core'
 include 'cicomponents-common'
 
+include 'cicomponents-badges-api'
+include 'cicomponents-badges'
+
 include 'cicomponents-fs-api'
 include 'cicomponents-fs'
 include 'cicomponents-git-api'


### PR DESCRIPTION
Solution: introduce cicomponents-badges to generate familiarly styled
badges (starting from shields.io flat style)
