### PR TITLE
Problem: Kryo includes ASM dependency which is already provided by Karaf

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ configurations {
         it.exclude group: 'org.apache.karaf.config'
         it.exclude group: 'org.apache.felix'
         it.exclude group: 'org.eclipse.jetty'
+        it.exclude group: 'org.ow2.asm'
     }
 
 }


### PR DESCRIPTION
This causes an error being logged due to API discrepancies

Solution: exclude ASM from shipping
