### PR TITLE
Problem: no easy way to share outputs over web

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,8 @@ configurations {
         it.exclude group: 'org.apache.felix'
         it.exclude group: 'org.eclipse.jetty'
         it.exclude group: 'org.ow2.asm'
+        it.exclude group: 'org.eclipse.jetty'
+        it.exclude group: 'org.eclipse.jetty.websocket'
     }
 
 }

--- a/cicomponents-core/build.gradle
+++ b/cicomponents-core/build.gradle
@@ -8,6 +8,11 @@ dependencies {
 
     compile 'com.esotericsoftware:kryo:4.0.0'
     compile 'com.h2database:h2-mvstore:1.4.192'
+
+    // Output streaming
+    compile 'javax.servlet:javax.servlet-api:3.1.0'
+    compile 'org.eclipse.jetty.websocket:websocket-server:9.2.15.v20160210'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.8.1'
 }
 
 

--- a/cicomponents-core/src/main/java/org/cicomponents/core/OutputServlet.java
+++ b/cicomponents-core/src/main/java/org/cicomponents/core/OutputServlet.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cicomponents.core;
+
+import com.google.common.io.CharStreams;
+import lombok.extern.slf4j.Slf4j;
+import org.osgi.service.component.annotations.Component;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+@WebServlet(
+        asyncSupported=true,
+        urlPatterns="/output/*"
+)
+@Slf4j
+@Component
+public class OutputServlet extends HttpServlet implements Servlet {
+    @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        resp.setContentType("text/html");
+        InputStream resourceAsStream = getClass().getResourceAsStream("output.html");
+        String s = CharStreams.toString(new InputStreamReader(resourceAsStream));
+        resp.getWriter().write(s);
+    }
+}

--- a/cicomponents-core/src/main/java/org/cicomponents/core/OutputWebSocketServlet.java
+++ b/cicomponents-core/src/main/java/org/cicomponents/core/OutputWebSocketServlet.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.cicomponents.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.cicomponents.OutputProvider;
+import org.cicomponents.OutputProviderRegistry;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.WebSocketAdapter;
+import org.eclipse.jetty.websocket.servlet.*;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import javax.servlet.Servlet;
+import javax.servlet.annotation.WebServlet;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@WebServlet(
+        asyncSupported=true,
+        urlPatterns="/output/ws/*"
+)
+@Slf4j
+@Component
+public class OutputWebSocketServlet extends WebSocketServlet implements Servlet {
+    @Reference
+    protected OutputProviderRegistry registry;
+
+    @Override public void configure(WebSocketServletFactory factory) {
+        factory.setCreator((req, resp) -> new Socket(registry));
+    }
+
+    static ExecutorService executor = Executors.newCachedThreadPool(
+            new ThreadFactoryBuilder().setNameFormat("output-ws-%d").build()
+    );
+
+    private static class Socket extends WebSocketAdapter {
+        private final OutputProviderRegistry registry;
+
+        public Socket(OutputProviderRegistry registry) {
+            this.registry = registry;
+        }
+
+        @Override public void onWebSocketConnect(Session sess) {
+            String[] pathComponents = sess.getUpgradeRequest().getRequestURI().getPath().split("/");
+            UUID uuid = UUID.fromString(pathComponents[pathComponents.length - 1]);
+            OutputProvider provider = registry.getProviders().get(uuid);
+            ObjectMapper mapper = new ObjectMapper();
+            executor.execute(() -> {
+                Iterator<OutputProvider.TimestampedOutput> iterator = provider.getOutput().iterator();
+                while (iterator.hasNext()) {
+                    if (!sess.isOpen()) {
+                        return;
+                    }
+                    try {
+                        sess.getRemote().sendString(mapper.writeValueAsString(iterator.next()));
+                    } catch (Exception e) {
+                        log.error("Exception while serializing a timestamped output", e);
+                        try {
+                            sess.disconnect();
+                        } catch (IOException e1) {
+                        }
+                    }
+                }
+            });
+        }
+    }
+}

--- a/cicomponents-core/src/main/resources/org/cicomponents/core/output.html
+++ b/cicomponents-core/src/main/resources/org/cicomponents/core/output.html
@@ -1,0 +1,80 @@
+<!--
+
+    Copyright (c) 2016, All Contributors (see CONTRIBUTORS file)
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<html>
+ <head>
+  <title>Output</title>
+  <link href='https://fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
+ </head>
+ <body style="background-color: black; width: 100%; height: 100%; color: #d0d0d0">
+ <pre id="output" style="font-family: Inconsolata, monospace">
+ </pre>
+
+ <script>
+     var pathComponents = window.location.pathname.split("/");
+     var uuid = pathComponents[pathComponents.length-1];
+     var rootOutput = document.getElementById("output");
+     rootOutput.innerHTML = "";
+     var output = document.createElement("span");
+     rootOutput.appendChild(output);
+     var ws = new WebSocket("ws://" + window.location.host + "/output/ws/" + uuid);
+     var buffer = [];
+     var connected;
+     var lastError = null;
+     var errorText = "";
+
+     var dequeue = function () {
+      var data;
+      var text = "";
+      var buflen = buffer.length;
+      while (typeof (data = buffer.shift()) != 'undefined') {
+        if (data.kind == "STDERR") {
+         if (!!lastError) {
+          errorText += atob(data.output);
+         } else {
+          output.innerText += text;
+          text = "";
+          errorText += atob(data.output);
+          lastError = document.createElement("span");
+          lastError.setAttribute("style", "color: red");
+         }
+        } else {
+         if (!!lastError) {
+          lastError.innerText = errorText;
+          rootOutput.appendChild(lastError);
+          output = document.createElement("span");
+          rootOutput.appendChild(output);
+          lastError = null;
+          errorText = "";
+         }
+         text += atob(data.output);
+        }
+      }
+      output.innerText += text;
+      if (buflen > 0) {
+       window.scrollTo(0, document.body.scrollHeight || document.documentElement.scrollHeight);
+      }
+      if (connected) {
+        setTimeout(dequeue, 100);
+       }
+     };
+     ws.onclose = function () {
+        connected = false;
+     };
+     ws.onopen = function() {
+        connected = true;
+        setTimeout(dequeue, 100);
+     };
+     ws.onmessage = function(msg) {
+         var data = JSON.parse(msg.data);
+         buffer.push(data);
+     };
+ </script>
+ </body>
+</html>


### PR DESCRIPTION
Right now outputs can be easily consumed using a Java API, but if one wants to
show them over a web page, it's not trivial.

Solution: Implement a websocket servlet at /output/ws/ID that streams a JSON
representation of the output

Also, another servlet at /output/ID serves a webpage that renders output from
the websocket servlet.

Closes #3
